### PR TITLE
Change logging level to DEBUG so that debug logs are also printed

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -21,7 +21,7 @@ from utils.const import zip_urls
 
 # Logging configuration
 logging.basicConfig(
-    level=logging.INFO,
+    level=logging.DEBUG,
     format="%(asctime)s [%(levelname)s]: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
     handlers = [


### PR DESCRIPTION
Currently the skipped images in pull_images_by_list function aren't printed. This will help print the debug messages now as well as more that we might add in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased logging verbosity to provide more detailed output for troubleshooting and diagnostic purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->